### PR TITLE
Adjust dsl of OIDC reflect assent requirements

### DIFF
--- a/lib/ash_authentication/strategies/oidc/dsl.ex
+++ b/lib/ash_authentication/strategies/oidc/dsl.ex
@@ -26,6 +26,10 @@ defmodule AshAuthentication.Strategy.Oidc.Dsl do
   defp patch_schema do
     OAuth2.dsl()
     |> Map.get(:schema, [])
+    |> make_required!(:base_url)
+    |> Keyword.delete(:authorize_url)
+    |> Keyword.delete(:token_url)
+    |> Keyword.delete(:redirect_uri)
     |> Keyword.delete(:user_url)
     |> Keyword.merge(
       openid_configuration_uri: [


### PR DESCRIPTION
The OIDC implementation of assent requires the base_url to be set and ignores the different *_url attributes. At favours the returned configuration from the openid_configuration_uri. To not configure some unused attributes they're removed.